### PR TITLE
State clearly the project's license - MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,25 @@
+Copyright 2019 SoloKeys Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -52,3 +52,5 @@ Run FIDO HID tests.
 node main/hid.js
 ```
 
+# License
+Distributed under MIT license.

--- a/main.js
+++ b/main.js
@@ -1,3 +1,9 @@
+// Copyright 2019 SoloKeys Developers
+//
+// Licensed under MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>. This file may not be copied, modified,
+// or distributed except according to those terms.
+
 const { ipcMain } = require('electron');
 const { app, BrowserWindow } = require('electron')
 const path = require('path'); 


### PR DESCRIPTION
Hi!

I have noticed that license under which this project is distributed is not stated anywhere besides the `package.json` file. Here is a PR to correct that.
Since I did not know, whether you would like to dual-license it as with Solo, I have cut out the Apache alternative.

https://github.com/solokeys/solo-desktop/blob/0c8a99ec84d7e3f1be23a0e6dc561b3990713981/package.json#L39